### PR TITLE
feat(dart): DART API 연동 및 고유번호 동기화

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,12 +20,14 @@
     "@prisma/client": "^7.3.0",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-query-devtools": "^5.91.2",
+    "adm-zip": "^0.5.16",
     "dotenv": "^17.2.3",
     "next": "^15.0.0",
     "pg": "^8.17.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "server-only": "^0.0.1"
+    "server-only": "^0.0.1",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@ds/eslint-config": "workspace:*",
@@ -33,10 +35,12 @@
     "@ds/typescript-config": "workspace:*",
     "@playwright/test": "^1.42.0",
     "@tailwindcss/postcss": "^4.1.17",
+    "@types/adm-zip": "^0.5.7",
     "@types/node": "^20",
     "@types/pg": "^8.16.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/xml2js": "^0.4.14",
     "eslint": "^8",
     "postcss": "^8",
     "prisma": "^7.3.0",

--- a/apps/web/prisma/migrations/20260128133340_add_stock_table/migration.sql
+++ b/apps/web/prisma/migrations/20260128133340_add_stock_table/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "stocks" (
+    "id" UUID NOT NULL,
+    "stock_code" VARCHAR(10) NOT NULL,
+    "corp_code" VARCHAR(8) NOT NULL,
+    "corp_name" VARCHAR(100) NOT NULL,
+    "market" VARCHAR(20),
+    "sector" VARCHAR(100),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "stocks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stocks_stock_code_key" ON "stocks"("stock_code");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stocks_corp_code_key" ON "stocks"("corp_code");
+
+-- CreateIndex
+CREATE INDEX "stocks_stock_code_idx" ON "stocks"("stock_code");
+
+-- CreateIndex
+CREATE INDEX "stocks_corp_code_idx" ON "stocks"("corp_code");
+
+-- CreateIndex
+CREATE INDEX "stocks_corp_name_idx" ON "stocks"("corp_name");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -7,7 +7,7 @@ datasource db {
   provider = "postgresql"
 }
 
-// 연결 테스트용 기본 테이블
+// 사용자
 model User {
   id        String   @id @default(uuid()) @db.Uuid
   email     String   @unique @db.VarChar(255)
@@ -16,4 +16,21 @@ model User {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("users")
+}
+
+// 종목 정보
+model Stock {
+  id        String   @id @default(uuid()) @db.Uuid
+  stockCode String   @unique @map("stock_code") @db.VarChar(10) // 종목코드 (005930)
+  corpCode  String   @unique @map("corp_code") @db.VarChar(8) // DART 고유번호 (8자리)
+  corpName  String   @map("corp_name") @db.VarChar(100) // 기업명
+  market    String?  @db.VarChar(20) // KOSPI, KOSDAQ, KONEX
+  sector    String?  @db.VarChar(100) // 업종
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([stockCode])
+  @@index([corpCode])
+  @@index([corpName])
+  @@map("stocks")
 }

--- a/apps/web/scripts/sync-corp-codes.ts
+++ b/apps/web/scripts/sync-corp-codes.ts
@@ -1,0 +1,106 @@
+/**
+ * DART 고유번호 동기화 스크립트
+ * 전체 상장 기업의 고유번호와 종목코드를 DB에 저장
+ */
+
+import { config } from 'dotenv'
+import { resolve } from 'path'
+import { PrismaClient } from '@prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { Pool } from 'pg'
+import { getCorpCodeList, filterListedCompanies } from '../shared/lib/dart'
+
+// .env.local 로드
+config({ path: resolve(__dirname, '../.env.local'), override: true })
+
+// Prisma 설정
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+const adapter = new PrismaPg(pool)
+const prisma = new PrismaClient({ adapter })
+
+async function syncCorpCodes() {
+  console.log('🚀 DART 고유번호 동기화 시작...\n')
+
+  try {
+    // 1. DART API에서 고유번호 목록 가져오기
+    console.log('📥 DART API에서 기업 정보 다운로드 중...')
+    const allCorpCodes = await getCorpCodeList()
+    console.log(`✅ 전체 기업 수: ${allCorpCodes.length}개`)
+
+    // 2. 상장 기업만 필터링
+    const listedCorps = filterListedCompanies(allCorpCodes)
+    console.log(`📊 상장 기업 수: ${listedCorps.length}개\n`)
+
+    // 3. DB에 저장
+    console.log('💾 데이터베이스에 저장 중...')
+
+    let successCount = 0
+    let errorCount = 0
+
+    for (const corp of listedCorps) {
+      try {
+        await prisma.stock.upsert({
+          where: { stockCode: corp.stockCode },
+          update: {
+            corpCode: corp.corpCode,
+            corpName: corp.corpName,
+            updatedAt: new Date(),
+          },
+          create: {
+            stockCode: corp.stockCode!,
+            corpCode: corp.corpCode,
+            corpName: corp.corpName,
+          },
+        })
+        successCount++
+
+        // 진행률 표시 (매 100개마다)
+        if (successCount % 100 === 0) {
+          const progress = ((successCount / listedCorps.length) * 100).toFixed(1)
+          console.log(`  진행중... ${successCount}/${listedCorps.length} (${progress}%)`)
+        }
+      } catch (error) {
+        errorCount++
+        console.error(`  ❌ 실패: ${corp.corpName} (${corp.stockCode})`, error)
+      }
+    }
+
+    console.log('\n✨ 동기화 완료!')
+    console.log('='.repeat(80))
+    console.log(`✅ 성공: ${successCount}개`)
+    console.log(`❌ 실패: ${errorCount}개`)
+    console.log('='.repeat(80))
+
+    // 4. 동기화 결과 확인
+    const totalStocks = await prisma.stock.count()
+    console.log(`\n📊 DB에 저장된 종목 수: ${totalStocks}개`)
+
+    // 5. 샘플 데이터 출력
+    const samples = await prisma.stock.findMany({
+      take: 5,
+      orderBy: { createdAt: 'desc' },
+    })
+
+    console.log('\n📌 최근 저장된 종목 (5개):')
+    console.log('='.repeat(80))
+    samples.forEach(stock => {
+      console.log(
+        `${stock.corpName.padEnd(20)} | 종목코드: ${stock.stockCode} | 고유번호: ${stock.corpCode}`
+      )
+    })
+    console.log('='.repeat(80))
+
+    console.log('\n✅ 모든 작업이 완료되었습니다!\n')
+  } catch (error) {
+    console.error('\n❌ 동기화 실패:', error)
+    if (error instanceof Error) {
+      console.error('상세 오류:', error.message)
+    }
+    process.exit(1)
+  } finally {
+    await prisma.$disconnect()
+    await pool.end()
+  }
+}
+
+syncCorpCodes()

--- a/apps/web/scripts/test-dart-api.ts
+++ b/apps/web/scripts/test-dart-api.ts
@@ -1,0 +1,73 @@
+/**
+ * DART API 연동 테스트 스크립트
+ */
+
+import { config } from 'dotenv'
+import { resolve } from 'path'
+import { getCorpCodeList, filterListedCompanies } from '../shared/lib/dart'
+
+// .env.local 로드
+config({ path: resolve(__dirname, '../.env.local'), override: true })
+
+async function testDartApi() {
+  console.log('🔌 DART API 연동 테스트 시작...\n')
+
+  try {
+    // 1. API 키 확인
+    if (!process.env.DART_API_KEY) {
+      console.error('❌ DART_API_KEY가 설정되지 않았습니다.')
+      console.log('\n📝 .env.local에 다음을 추가하세요:')
+      console.log('DART_API_KEY="YOUR_API_KEY"')
+      console.log('\nAPI 키 발급: https://opendart.fss.or.kr')
+      process.exit(1)
+    }
+
+    console.log('✓ DART_API_KEY 로드됨\n')
+
+    // 2. 고유번호 전체 목록 조회
+    console.log('📥 고유번호 목록 다운로드 중...')
+    const allCorpCodes = await getCorpCodeList()
+    console.log(`✅ 전체 기업 수: ${allCorpCodes.length}개\n`)
+
+    // 3. 상장 기업만 필터링
+    const listedCorps = filterListedCompanies(allCorpCodes)
+    console.log(`📊 상장 기업 수: ${listedCorps.length}개`)
+    console.log(`📋 비상장 기업 수: ${allCorpCodes.length - listedCorps.length}개\n`)
+
+    // 4. 샘플 데이터 출력
+    console.log('📌 상장 기업 샘플 (처음 5개):')
+    console.log('='.repeat(80))
+    listedCorps.slice(0, 5).forEach(corp => {
+      console.log(
+        `${corp.corpName.padEnd(20)} | 종목코드: ${corp.stockCode} | 고유번호: ${corp.corpCode}`
+      )
+    })
+    console.log('='.repeat(80))
+
+    // 5. 특정 기업 검색 테스트
+    const testCompanies = ['삼성전자', 'SK하이닉스', '카카오', 'NAVER']
+    console.log('\n🔍 주요 기업 검색 테스트:')
+    console.log('='.repeat(80))
+    testCompanies.forEach(name => {
+      const found = listedCorps.find(corp => corp.corpName.includes(name))
+      if (found) {
+        console.log(
+          `✅ ${found.corpName.padEnd(20)} | 종목: ${found.stockCode} | 고유번호: ${found.corpCode}`
+        )
+      } else {
+        console.log(`❌ ${name} - 찾을 수 없음`)
+      }
+    })
+    console.log('='.repeat(80))
+
+    console.log('\n✨ DART API 테스트 완료!\n')
+  } catch (error) {
+    console.error('\n❌ DART API 테스트 실패:', error)
+    if (error instanceof Error) {
+      console.error('상세 오류:', error.message)
+    }
+    process.exit(1)
+  }
+}
+
+testDartApi()

--- a/apps/web/shared/lib/dart/apis/corp-code.ts
+++ b/apps/web/shared/lib/dart/apis/corp-code.ts
@@ -1,0 +1,71 @@
+/**
+ * DART 고유번호 조회 API
+ * 전체 상장/비상장 기업의 고유번호, 종목코드, 기업명 정보 제공
+ */
+
+import AdmZip from 'adm-zip'
+import { parseStringPromise } from 'xml2js'
+import { downloadZipFile } from '../client'
+import type { CorpCode, CorpCodeResponse } from '../types'
+
+/**
+ * 고유번호 전체 목록 조회
+ * ZIP 파일을 다운로드하여 XML을 파싱하고 기업 목록을 반환
+ *
+ * @returns 전체 기업 고유번호 목록
+ */
+export async function getCorpCodeList(): Promise<CorpCode[]> {
+  try {
+    // 1. ZIP 파일 다운로드
+    const zipBuffer = await downloadZipFile('corpCode.xml')
+
+    // 2. ZIP 압축 해제
+    const zip = new AdmZip(zipBuffer)
+    const zipEntries = zip.getEntries()
+
+    if (zipEntries.length === 0) {
+      throw new Error('ZIP 파일에 데이터가 없습니다.')
+    }
+
+    // 첫 번째 파일(CORPCODE.xml) 추출
+    const xmlData = zipEntries[0].getData().toString('utf8')
+
+    // 3. XML 파싱
+    const parsed = await parseStringPromise(xmlData, {
+      explicitArray: true,
+      trim: true,
+    })
+
+    const result = parsed as CorpCodeResponse
+
+    if (!result.result?.list) {
+      throw new Error('XML 파싱 결과가 올바르지 않습니다.')
+    }
+
+    // 4. 데이터 변환
+    const corpCodes: CorpCode[] = result.result.list.map(item => {
+      const stockCode = item.stock_code?.[0]?.trim()
+
+      return {
+        corpCode: item.corp_code[0],
+        corpName: item.corp_name[0],
+        stockCode: stockCode && stockCode !== ' ' ? stockCode : undefined,
+        modifyDate: item.modify_date[0],
+      }
+    })
+
+    return corpCodes
+  } catch (error) {
+    console.error('고유번호 조회 실패:', error)
+    throw new Error(
+      `DART 고유번호 조회 API 오류: ${error instanceof Error ? error.message : '알 수 없는 오류'}`
+    )
+  }
+}
+
+/**
+ * 상장 기업만 필터링
+ */
+export function filterListedCompanies(corpCodes: CorpCode[]): CorpCode[] {
+  return corpCodes.filter(corp => corp.stockCode !== undefined)
+}

--- a/apps/web/shared/lib/dart/client.ts
+++ b/apps/web/shared/lib/dart/client.ts
@@ -1,0 +1,56 @@
+/**
+ * DART Open API 클라이언트
+ * @see https://opendart.fss.or.kr/guide/detail.do?apiGrpCd=DS001&apiId=2019018
+ */
+
+const DART_API_BASE_URL = 'https://opendart.fss.or.kr/api'
+
+/**
+ * DART API 요청 헬퍼
+ */
+async function dartFetch(endpoint: string, params: Record<string, string> = {}) {
+  const apiKey = process.env.DART_API_KEY
+
+  if (!apiKey) {
+    throw new Error('DART_API_KEY가 설정되지 않았습니다.')
+  }
+
+  const url = new URL(`${DART_API_BASE_URL}/${endpoint}`)
+  url.searchParams.append('crtfc_key', apiKey)
+
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.append(key, value)
+  })
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: '*/*',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`DART API 요청 실패: ${response.status} ${response.statusText}`)
+  }
+
+  return response
+}
+
+/**
+ * ZIP 파일을 Buffer로 다운로드
+ */
+export async function downloadZipFile(endpoint: string): Promise<Buffer> {
+  const response = await dartFetch(endpoint)
+  const arrayBuffer = await response.arrayBuffer()
+  return Buffer.from(arrayBuffer)
+}
+
+/**
+ * JSON 응답 가져오기
+ */
+export async function fetchJson<T>(
+  endpoint: string,
+  params: Record<string, string> = {}
+): Promise<T> {
+  const response = await dartFetch(endpoint, params)
+  return response.json()
+}

--- a/apps/web/shared/lib/dart/index.ts
+++ b/apps/web/shared/lib/dart/index.ts
@@ -1,0 +1,5 @@
+// DART API 클라이언트 barrel export
+
+export * from './types'
+export * from './client'
+export * from './apis/corp-code'

--- a/apps/web/shared/lib/dart/types.ts
+++ b/apps/web/shared/lib/dart/types.ts
@@ -1,0 +1,33 @@
+// DART API 응답 타입
+
+/**
+ * 기업 고유번호 정보
+ */
+export interface CorpCode {
+  corpCode: string // 고유번호 (8자리)
+  corpName: string // 기업명
+  stockCode?: string // 종목코드 (6자리, 상장사만 존재)
+  modifyDate: string // 최종변경일자 (YYYYMMDD)
+}
+
+/**
+ * 고유번호 조회 API 응답 (XML 파싱 결과)
+ */
+export interface CorpCodeResponse {
+  result: {
+    list: Array<{
+      corp_code: string[]
+      corp_name: string[]
+      stock_code: string[]
+      modify_date: string[]
+    }>
+  }
+}
+
+/**
+ * DART API 에러 응답
+ */
+export interface DartErrorResponse {
+  status: string
+  message: string
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.91.2
         version: 5.91.2(@tanstack/react-query@5.90.20(react@18.3.1))(react@18.3.1)
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.16
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -120,6 +123,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      xml2js:
+        specifier: ^0.6.2
+        version: 0.6.2
     devDependencies:
       '@ds/eslint-config':
         specifier: workspace:*
@@ -136,6 +142,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.17
         version: 4.1.18
+      '@types/adm-zip':
+        specifier: ^0.5.7
+        version: 0.5.7
       '@types/node':
         specifier: ^20
         version: 20.19.30
@@ -148,6 +157,9 @@ importers:
       '@types/react-dom':
         specifier: ^18
         version: 18.3.7(@types/react@18.3.27)
+      '@types/xml2js':
+        specifier: ^0.4.14
+        version: 0.4.14
       eslint:
         specifier: ^8
         version: 8.57.1
@@ -2451,6 +2463,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/adm-zip@0.5.7':
+    resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
@@ -2509,6 +2524,9 @@ packages:
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+
+  '@types/xml2js@0.4.14':
+    resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -2751,6 +2769,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -5018,6 +5040,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.4.4:
+    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
+    engines: {node: '>=11.0.0'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -5717,6 +5743,14 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -7806,6 +7840,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/adm-zip@0.5.7':
+    dependencies:
+      '@types/node': 20.19.30
+
   '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
@@ -7869,6 +7907,10 @@ snapshots:
   '@types/resolve@1.20.6': {}
 
   '@types/uuid@9.0.8': {}
+
+  '@types/xml2js@0.4.14':
+    dependencies:
+      '@types/node': 20.19.30
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -8144,6 +8186,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  adm-zip@0.5.16: {}
 
   agent-base@7.1.4: {}
 
@@ -10635,6 +10679,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.4.4: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -11364,6 +11410,13 @@ snapshots:
   ws@8.19.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.4.4
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## 구현 내용

DART(전자공시시스템) Open API를 연동하여 전체 상장 기업의 고유번호와 종목코드를 DB에 동기화하는 기능을 구현했습니다.

## 주요 변경사항

### 1. DART API 클라이언트 구현
- `shared/lib/dart/client.ts`: DART API HTTP 클라이언트
- `shared/lib/dart/types.ts`: DART API 타입 정의
- `shared/lib/dart/apis/corp-code.ts`: 고유번호 조회 API
  - ZIP 파일 다운로드 및 압축 해제 (adm-zip)
  - XML 파싱 (xml2js)
  - 상장/비상장 기업 필터링

### 2. 데이터베이스 스키마 확장
- Stock 테이블 추가 (종목코드, DART 고유번호, 기업명, 시장, 업종)
- 마이그레이션: `20260128133340_add_stock_table`
- 인덱스: stockCode, corpCode, corpName

### 3. 동기화 스크립트
- `scripts/test-dart-api.ts`: DART API 연결 테스트
- `scripts/sync-corp-codes.ts`: 상장 기업 DB 동기화

## 테스트 결과

```
✅ 전체 기업 수: 115,066개
✅ 상장 기업 수: 3,945개
✅ DB 동기화: 3,945개 성공, 0개 실패
```

## 기술 스택

- adm-zip: ZIP 파일 처리
- xml2js: XML 파싱
- Prisma: ORM 및 마이그레이션

---

🤖 Generated with Claude Code