### PR TITLE
feat(db): 핵심 데이터베이스 스키마 구축

### DIFF
--- a/apps/web/prisma/migrations/20260128135435_add_core_tables/migration.sql
+++ b/apps/web/prisma/migrations/20260128135435_add_core_tables/migration.sql
@@ -1,0 +1,172 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "notification_email" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "notification_telegram" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "telegram_chat_id" VARCHAR(50);
+
+-- CreateTable
+CREATE TABLE "watchlist" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "stock_id" UUID NOT NULL,
+    "notify_regular" BOOLEAN NOT NULL DEFAULT true,
+    "notify_major" BOOLEAN NOT NULL DEFAULT true,
+    "notify_equity" BOOLEAN NOT NULL DEFAULT true,
+    "notify_securities" BOOLEAN NOT NULL DEFAULT false,
+    "priority" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "watchlist_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "disclosures" (
+    "id" UUID NOT NULL,
+    "stock_id" UUID NOT NULL,
+    "rcept_no" VARCHAR(20) NOT NULL,
+    "rcept_dt" DATE NOT NULL,
+    "report_nm" VARCHAR(500) NOT NULL,
+    "dcm_type" VARCHAR(10),
+    "dart_url" VARCHAR(500),
+    "ai_summary" TEXT,
+    "ai_sentiment" VARCHAR(20),
+    "ai_key_figures" JSONB,
+    "ai_analysis" TEXT,
+    "ai_analyzed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "disclosures_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "financial_data" (
+    "id" UUID NOT NULL,
+    "stock_id" UUID NOT NULL,
+    "bsns_year" VARCHAR(4) NOT NULL,
+    "reprt_code" VARCHAR(10) NOT NULL,
+    "revenue" BIGINT,
+    "operating_profit" BIGINT,
+    "net_income" BIGINT,
+    "total_assets" BIGINT,
+    "total_liabilities" BIGINT,
+    "total_equity" BIGINT,
+    "raw_data" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "financial_data_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ai_reports" (
+    "id" UUID NOT NULL,
+    "stock_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "report_type" VARCHAR(20) NOT NULL,
+    "report_content" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ai_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ai_conversations" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "disclosure_id" UUID NOT NULL,
+    "role" VARCHAR(20) NOT NULL,
+    "content" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ai_conversations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "disclosure_id" UUID,
+    "title" VARCHAR(200) NOT NULL,
+    "content" TEXT,
+    "channel" VARCHAR(20) NOT NULL,
+    "is_read" BOOLEAN NOT NULL DEFAULT false,
+    "sent_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "watchlist_user_id_idx" ON "watchlist"("user_id");
+
+-- CreateIndex
+CREATE INDEX "watchlist_stock_id_idx" ON "watchlist"("stock_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "watchlist_user_id_stock_id_key" ON "watchlist"("user_id", "stock_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "disclosures_rcept_no_key" ON "disclosures"("rcept_no");
+
+-- CreateIndex
+CREATE INDEX "disclosures_stock_id_idx" ON "disclosures"("stock_id");
+
+-- CreateIndex
+CREATE INDEX "disclosures_rcept_dt_idx" ON "disclosures"("rcept_dt");
+
+-- CreateIndex
+CREATE INDEX "disclosures_dcm_type_idx" ON "disclosures"("dcm_type");
+
+-- CreateIndex
+CREATE INDEX "financial_data_stock_id_idx" ON "financial_data"("stock_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "financial_data_stock_id_bsns_year_reprt_code_key" ON "financial_data"("stock_id", "bsns_year", "reprt_code");
+
+-- CreateIndex
+CREATE INDEX "ai_reports_stock_id_idx" ON "ai_reports"("stock_id");
+
+-- CreateIndex
+CREATE INDEX "ai_reports_user_id_idx" ON "ai_reports"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ai_conversations_user_id_idx" ON "ai_conversations"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ai_conversations_disclosure_id_idx" ON "ai_conversations"("disclosure_id");
+
+-- CreateIndex
+CREATE INDEX "notifications_user_id_idx" ON "notifications"("user_id");
+
+-- CreateIndex
+CREATE INDEX "notifications_disclosure_id_idx" ON "notifications"("disclosure_id");
+
+-- CreateIndex
+CREATE INDEX "notifications_is_read_idx" ON "notifications"("is_read");
+
+-- AddForeignKey
+ALTER TABLE "watchlist" ADD CONSTRAINT "watchlist_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "watchlist" ADD CONSTRAINT "watchlist_stock_id_fkey" FOREIGN KEY ("stock_id") REFERENCES "stocks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "disclosures" ADD CONSTRAINT "disclosures_stock_id_fkey" FOREIGN KEY ("stock_id") REFERENCES "stocks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "financial_data" ADD CONSTRAINT "financial_data_stock_id_fkey" FOREIGN KEY ("stock_id") REFERENCES "stocks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ai_reports" ADD CONSTRAINT "ai_reports_stock_id_fkey" FOREIGN KEY ("stock_id") REFERENCES "stocks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ai_reports" ADD CONSTRAINT "ai_reports_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ai_conversations" ADD CONSTRAINT "ai_conversations_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ai_conversations" ADD CONSTRAINT "ai_conversations_disclosure_id_fkey" FOREIGN KEY ("disclosure_id") REFERENCES "disclosures"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_disclosure_id_fkey" FOREIGN KEY ("disclosure_id") REFERENCES "disclosures"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -9,11 +9,19 @@ datasource db {
 
 // 사용자
 model User {
-  id        String   @id @default(uuid()) @db.Uuid
-  email     String   @unique @db.VarChar(255)
-  name      String?  @db.VarChar(100)
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  id                    String   @id @default(uuid()) @db.Uuid
+  email                 String   @unique @db.VarChar(255)
+  name                  String?  @db.VarChar(100)
+  telegramChatId        String?  @map("telegram_chat_id") @db.VarChar(50)
+  notificationEmail     Boolean  @default(true) @map("notification_email")
+  notificationTelegram  Boolean  @default(false) @map("notification_telegram")
+  createdAt             DateTime @default(now()) @map("created_at")
+  updatedAt             DateTime @updatedAt @map("updated_at")
+
+  watchlist      Watchlist[]
+  aiReports      AiReport[]
+  aiConversations AiConversation[]
+  notifications  Notification[]
 
   @@map("users")
 }
@@ -29,8 +37,136 @@ model Stock {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
+  watchlist      Watchlist[]
+  disclosures    Disclosure[]
+  financialData  FinancialData[]
+  aiReports      AiReport[]
+
   @@index([stockCode])
   @@index([corpCode])
   @@index([corpName])
   @@map("stocks")
+}
+
+// 관심 종목
+model Watchlist {
+  id              String   @id @default(uuid()) @db.Uuid
+  userId          String   @map("user_id") @db.Uuid
+  stockId         String   @map("stock_id") @db.Uuid
+  notifyRegular   Boolean  @default(true) @map("notify_regular") // 정기보고서
+  notifyMajor     Boolean  @default(true) @map("notify_major") // 주요사항보고
+  notifyEquity    Boolean  @default(true) @map("notify_equity") // 지분공시
+  notifySecurities Boolean @default(false) @map("notify_securities") // 증권신고서
+  priority        Int      @default(0) // 우선순위
+  createdAt       DateTime @default(now()) @map("created_at")
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  stock Stock @relation(fields: [stockId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, stockId])
+  @@index([userId])
+  @@index([stockId])
+  @@map("watchlist")
+}
+
+// 공시
+model Disclosure {
+  id            String    @id @default(uuid()) @db.Uuid
+  stockId       String    @map("stock_id") @db.Uuid
+  rceptNo       String    @unique @map("rcept_no") @db.VarChar(20) // 접수번호
+  rceptDt       DateTime  @map("rcept_dt") @db.Date // 접수일자
+  reportNm      String    @map("report_nm") @db.VarChar(500) // 보고서명
+  dcmType       String?   @map("dcm_type") @db.VarChar(10) // 공시유형 (A:정기, B:주요, C:발행, D:지분, E:기타)
+  dartUrl       String?   @map("dart_url") @db.VarChar(500) // 원문 링크
+  aiSummary     String?   @map("ai_summary") @db.Text // 3줄 요약
+  aiSentiment   String?   @map("ai_sentiment") @db.VarChar(20) // 호재/악재/중립
+  aiKeyFigures  Json?     @map("ai_key_figures") // 핵심 수치
+  aiAnalysis    String?   @map("ai_analysis") @db.Text // 상세 분석
+  aiAnalyzedAt  DateTime? @map("ai_analyzed_at") // AI 분석 시각
+  createdAt     DateTime  @default(now()) @map("created_at")
+
+  stock          Stock            @relation(fields: [stockId], references: [id], onDelete: Cascade)
+  aiConversations AiConversation[]
+  notifications  Notification[]
+
+  @@index([stockId])
+  @@index([rceptDt])
+  @@index([dcmType])
+  @@map("disclosures")
+}
+
+// 재무 데이터
+model FinancialData {
+  id               String   @id @default(uuid()) @db.Uuid
+  stockId          String   @map("stock_id") @db.Uuid
+  bsnsYear         String   @map("bsns_year") @db.VarChar(4) // 사업연도
+  reprtCode        String   @map("reprt_code") @db.VarChar(10) // 보고서코드 (11013:1분기, 11012:반기, 11014:3분기, 11011:사업)
+  revenue          BigInt?  // 매출액
+  operatingProfit  BigInt?  @map("operating_profit") // 영업이익
+  netIncome        BigInt?  @map("net_income") // 당기순이익
+  totalAssets      BigInt?  @map("total_assets") // 자산총계
+  totalLiabilities BigInt?  @map("total_liabilities") // 부채총계
+  totalEquity      BigInt?  @map("total_equity") // 자본총계
+  rawData          Json?    @map("raw_data") // 상세 데이터 (JSON)
+  createdAt        DateTime @default(now()) @map("created_at")
+
+  stock Stock @relation(fields: [stockId], references: [id], onDelete: Cascade)
+
+  @@unique([stockId, bsnsYear, reprtCode])
+  @@index([stockId])
+  @@map("financial_data")
+}
+
+// AI 분석 리포트
+model AiReport {
+  id            String   @id @default(uuid()) @db.Uuid
+  stockId       String   @map("stock_id") @db.Uuid
+  userId        String   @map("user_id") @db.Uuid
+  reportType    String   @map("report_type") @db.VarChar(20) // FULL, FINANCIAL, DIVIDEND
+  reportContent Json     @map("report_content") // 리포트 전체 내용
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  stock Stock @relation(fields: [stockId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([stockId])
+  @@index([userId])
+  @@map("ai_reports")
+}
+
+// AI 대화
+model AiConversation {
+  id           String   @id @default(uuid()) @db.Uuid
+  userId       String   @map("user_id") @db.Uuid
+  disclosureId String   @map("disclosure_id") @db.Uuid
+  role         String   @db.VarChar(20) // USER, ASSISTANT
+  content      String   @db.Text
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  disclosure Disclosure @relation(fields: [disclosureId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([disclosureId])
+  @@map("ai_conversations")
+}
+
+// 알림 기록
+model Notification {
+  id           String    @id @default(uuid()) @db.Uuid
+  userId       String    @map("user_id") @db.Uuid
+  disclosureId String?   @map("disclosure_id") @db.Uuid
+  title        String    @db.VarChar(200)
+  content      String?   @db.Text
+  channel      String    @db.VarChar(20) // IN_APP, TELEGRAM, EMAIL
+  isRead       Boolean   @default(false) @map("is_read")
+  sentAt       DateTime  @default(now()) @map("sent_at")
+
+  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  disclosure Disclosure? @relation(fields: [disclosureId], references: [id], onDelete: SetNull)
+
+  @@index([userId])
+  @@index([disclosureId])
+  @@index([isRead])
+  @@map("notifications")
 }


### PR DESCRIPTION
## 구현 내용

AI 공시 분석 서비스의 핵심 기능을 위한 데이터베이스 스키마를 구축했습니다.

## 주요 변경사항

### 1. User 테이블 확장
- `telegramChatId`: 텔레그램 알림용 채팅 ID
- `notificationEmail`: 이메일 알림 ON/OFF
- `notificationTelegram`: 텔레그램 알림 ON/OFF

### 2. 새로운 테이블 추가

#### Watchlist (관심 종목)
- 사용자별 관심 종목 등록 (최대 20개)
- 공시 유형별 알림 설정 (정기보고서, 주요사항보고, 지분공시, 증권신고서)
- 우선순위 설정
- 중복 방지: `UNIQUE(userId, stockId)`

#### Disclosure (공시)
- DART 공시 원본 정보 (접수번호, 보고서명, 공시유형)
- AI 분석 결과
  - 3줄 요약 (`aiSummary`)
  - 호재/악재 판단 (`aiSentiment`)
  - 핵심 수치 (`aiKeyFigures` - JSON)
  - 상세 분석 (`aiAnalysis`)
- 접수번호 유니크 인덱스

#### FinancialData (재무 데이터)
- 분기별/연도별 재무제표 데이터
- 매출액, 영업이익, 순이익, 자산, 부채, 자본
- 원본 데이터 JSON 저장 (`rawData`)
- 중복 방지: `UNIQUE(stockId, bsnsYear, reprtCode)`

#### AiReport (AI 분석 리포트)
- 기업 분석 리포트 저장
- 리포트 타입: FULL, FINANCIAL, DIVIDEND
- 리포트 내용 JSON 저장

#### AiConversation (AI 대화)
- 공시에 대한 사용자 질문/답변 기록
- 대화 컨텍스트 유지용

#### Notification (알림 기록)
- 알림 이력 관리
- 채널: IN_APP, TELEGRAM, EMAIL
- 읽음/안읽음 상태 관리

### 3. 관계 설정
- 모든 테이블 간 적절한 외래키 설정
- Cascade 삭제 정책 (사용자/종목 삭제 시 연관 데이터 자동 삭제)
- 최적화된 인덱스 설정

## 데이터베이스 구조

```
users (사용자)
  ├─ watchlist (관심 종목)
  ├─ ai_reports (AI 리포트)
  ├─ ai_conversations (AI 대화)
  └─ notifications (알림)

stocks (종목 정보)
  ├─ watchlist (관심 종목)
  ├─ disclosures (공시)
  ├─ financial_data (재무 데이터)
  └─ ai_reports (AI 리포트)

disclosures (공시)
  ├─ ai_conversations (AI 대화)
  └─ notifications (알림)
```

## 다음 단계

이 스키마를 기반으로 다음 기능 구현 가능:
- 관심 종목 CRUD
- 공시 폴링 및 AI 분석
- 재무제표 수집 및 분석
- AI 리포트 생성
- 알림 시스템

---

🤖 Generated with Claude Code