### PR TITLE
fix: 모바일 스크롤 시 헤더 빈 공간 문제 수정

### DIFF
--- a/apps/web/widgets/header/ui/mobile-header.tsx
+++ b/apps/web/widgets/header/ui/mobile-header.tsx
@@ -10,8 +10,8 @@ interface MobileHeaderProps {
 
 export function MobileHeader({ left, center, right }: MobileHeaderProps) {
   return (
-    <div className="md:hidden">
-      <header className="bg-card sticky top-0 z-50 flex h-14 items-center px-4 backdrop-blur">
+    <div className="sticky top-0 z-50 md:hidden">
+      <header className="bg-card flex h-14 items-center px-4 backdrop-blur">
         {/* 좌측 */}
         <div className="flex min-w-0 flex-1 items-center">{left}</div>
 

--- a/apps/web/widgets/today-disclosures/today-disclosures.tsx
+++ b/apps/web/widgets/today-disclosures/today-disclosures.tsx
@@ -89,7 +89,7 @@ export function TodayDisclosures() {
           <h2 className="text-lg font-bold">오늘의 공시</h2>
         </div>
 
-        <div className="mb-2">
+        <div className="sticky top-14 z-40 mb-2 bg-card">
           <MarketTabs selectedMarket={selectedMarket} onMarketChange={handleMarketChange} />
         </div>
 


### PR DESCRIPTION
## Summary
- MobileHeader의 sticky를 wrapper div로 이동하여 스크롤 시 헤더가 정상 고정되도록 수정
- 오늘의 공시 모바일 탭바에 sticky 적용하여 헤더 아래 고정

Closes #14

## Test plan
- [x] 모바일(768px 미만)에서 스크롤 시 헤더가 상단에 고정되는지 확인
- [x] 모바일에서 스크롤 시 탭바가 헤더 바로 아래에 고정되는지 확인
- [x] PC(768px 이상)에서 모바일 헤더가 보이지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)